### PR TITLE
Increase default falling star height, add config to adjust height of where a falling star spawns.

### DIFF
--- a/src/main/java/com/idreesinc/celeste/FallingStar.java
+++ b/src/main/java/com/idreesinc/celeste/FallingStar.java
@@ -19,7 +19,7 @@ public class FallingStar extends BukkitRunnable {
     private final Location location;
     private final Location dropLoc;
     private final CelesteConfig config;
-    private double y = 256;
+    private double y = 320;
     private boolean soundPlayed = false;
     private boolean lootDropped = false;
     private int sparkTimer;
@@ -31,10 +31,11 @@ public class FallingStar extends BukkitRunnable {
         sparkTimer = config.fallingStarsSparkTime;
         dropLoc = new Location(location.getWorld(), location.getX(),
                 location.getWorld().getHighestBlockAt(location).getY() + 1, location.getZ());
+        y = celeste.getConfig().getDouble("falling-stars-max-height");
     }
 
     public void run() {
-        double step = 1;
+        double step = 2; // Speed of fall increased to compensate for increased height.
         location.getWorld().spawnParticle(Particle.FIREWORKS_SPARK, location.getX(), y, location.getZ(),
                 0,  0,  new Random().nextDouble(), 0,
                 0.2, null, true);
@@ -49,7 +50,7 @@ public class FallingStar extends BukkitRunnable {
                     0,  0, new Random().nextDouble(), 0,
                     0.2, null, true);
         }
-        if (config.fallingStarsSoundEnabled && !soundPlayed && y <= dropLoc.getY() + 75) {
+        if (config.fallingStarsSoundEnabled && !soundPlayed && y <= dropLoc.getY() + 75*step) {
             location.getWorld().playSound(dropLoc, Sound.BLOCK_BELL_RESONATE, (float) config.fallingStarsVolume, 0.5f);
             soundPlayed = true;
         }

--- a/src/main/java/com/idreesinc/celeste/FallingStar.java
+++ b/src/main/java/com/idreesinc/celeste/FallingStar.java
@@ -19,7 +19,7 @@ public class FallingStar extends BukkitRunnable {
     private final Location location;
     private final Location dropLoc;
     private final CelesteConfig config;
-    private double y = 320;
+    private double y = 330;
     private boolean soundPlayed = false;
     private boolean lootDropped = false;
     private int sparkTimer;

--- a/src/main/java/com/idreesinc/celeste/config/CelesteConfig.java
+++ b/src/main/java/com/idreesinc/celeste/config/CelesteConfig.java
@@ -16,6 +16,7 @@ public class CelesteConfig {
     public int shootingStarsMaxHeight;
 
     public boolean fallingStarsEnabled;
+    public double fallingStarsMaxHeight;
     public double fallingStarsPerMinute;
     public double fallingStarsPerMinuteMeteorShower;
     public int fallingStarsRadius;
@@ -48,6 +49,7 @@ public class CelesteConfig {
         shootingStarsMaxHeight = section.getInt("shooting-stars-max-height");
 
         fallingStarsEnabled = section.getBoolean("falling-stars-enabled");
+        fallingStarsMaxHeight = section.getDouble("falling-stars-max-height");
         fallingStarsPerMinute = section.getDouble("falling-stars-per-minute");
         fallingStarsPerMinuteMeteorShower = section.getDouble("falling-stars-per-minute-during-meteor-showers");
         fallingStarsRadius = section.getInt("falling-stars-radius");
@@ -74,6 +76,7 @@ public class CelesteConfig {
         shootingStarsMaxHeight = section.getInt("shooting-stars-max-height", globalConfig.shootingStarsMaxHeight);
 
         fallingStarsEnabled = section.getBoolean("falling-stars-enabled", globalConfig.fallingStarsEnabled);
+        fallingStarsMaxHeight = section.getDouble("falling-stars-max-height", globalConfig.fallingStarsMaxHeight);
         fallingStarsPerMinute = section.getDouble("falling-stars-per-minute", globalConfig.fallingStarsPerMinute);
         fallingStarsPerMinuteMeteorShower = section.getDouble("falling-stars-per-minute-during-meteor-showers", globalConfig.fallingStarsPerMinuteMeteorShower);
         fallingStarsRadius = section.getInt("falling-stars-radius", globalConfig.fallingStarsRadius);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -7,6 +7,7 @@ shooting-stars-per-minute: 6
 shooting-stars-min-height: 130
 shooting-stars-max-height: 160
 falling-stars-per-minute: 0.2
+falling-stars-max-height: 330
 falling-stars-radius: 75
 falling-stars-sound-enabled: true
 falling-stars-volume: 6


### PR DESCRIPTION
Fix for #8. Set the new default height to y=330 to compensate for increased terrain height in new versions of minecraft. Also, added a new config option "falling-stars-max-height" so this can be configured.
Note that with the new height, the speed at which the stars fell was sluggish, so I increased the speed as well. 